### PR TITLE
Fix for db_definition_template.pp -> db_control should run as the $os_user

### DIFF
--- a/manifests/database/db_definition_template.pp
+++ b/manifests/database/db_definition_template.pp
@@ -195,6 +195,7 @@ class ora_profile::database::db_definition_template(
     provider                => $db_control_provider,
     instance_name           => $dbname,
     oracle_product_home_dir => $oracle_home,
+    os_user                 => $os_user,
   }
 
   if ( $is_rac ) {


### PR DESCRIPTION
Small fix to fix an error when starting the database, it cannot be started as user root