### PR TITLE
[ora_profile] Small bug fixes

### DIFF
--- a/data/os-major/RedHat-6.yaml
+++ b/data/os-major/RedHat-6.yaml
@@ -1,3 +1,7 @@
+---
+ora_profile::database::firewall::manage_service:                          false # Doesn't work in RH6
+ora_profile::database::tmpfiles:                                          skip  # There is no tmpfiles service in RH6
+
 # ------------------------------------------------------------------------------
 #
 # Settings for database::packages
@@ -33,7 +37,7 @@ ora_profile::database::packages::list:
   libxcb.x86_64: {}
   libXrender.x86_64: {}
   libXrender-devel.x86_64: {}
-  makex86_64: {}
+  make.x86_64: {}
   sysstat.x86_64: {}
 
 

--- a/manifests/database/db_patches.pp
+++ b/manifests/database/db_patches.pp
@@ -311,6 +311,7 @@ class ora_profile::database::db_patches(
                 instance_name           => $dbname,
                 oracle_product_home_dir => $patch_home,
                 os_user                 => $os_user,
+                provider                => $db_control_provider,
                 require                 => Ora_opatch[$apply_patches.keys],
                 schedule                => $schedule,
               }

--- a/templates/init.ora.epp
+++ b/templates/init.ora.epp
@@ -102,6 +102,4 @@ memory_max_target=<%= $memory_max_target %>
 ###########################################
 <% if $container_database == 'enabled' { -%>
 enable_pluggable_database=true
-<% } else { -%>
-enable_pluggable_database=false
 <% } -%>


### PR DESCRIPTION
- [firewall] Fix firewall service in RH6
- [tmpfiles] Skip tmpfiles in RH6
- [packages] Fix typo for make package in RH6
- [db_patches] Use the right provider for starting database
- [db_definition] Remove else for container_database in init.ora template (false is default)
                  So it works for Oracle 11g too

Change-Id: I00152e68625a80b2a774d1b95ff59c4be71aa5e5